### PR TITLE
ci(release): update release-please-action to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3
         with:
           release-type: simple
           package-name: release


### PR DESCRIPTION
Update the GitHub action from googleapis/release-please-action to google-github-actions/release-please-action to use the latest version and maintain compatibility