### PR TITLE
ci(docker): remove onlatest flag from dev image flavor

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
             type=semver,pattern={{version}}
             type=sha,format=short
           flavor: |
-            suffix=-dev,onlatest=true,enable=${{ github.ref == 'refs/heads/dev' }}
+            suffix=-dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Push image to GitHub Container Registry
         uses: docker/build-push-action@v5


### PR DESCRIPTION
The onlatest flag was redundant since we only want to tag dev builds with -dev suffix when on dev branch