### PR TITLE
ci: remove conditional suffix from docker image flavor

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,7 +61,7 @@ jobs:
             type=sha,format=short
           flavor: |
             latest=auto
-            suffix=-dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            suffix=-dev
 
       - name: Push image to GitHub Container Registry
         uses: docker/build-push-action@v5


### PR DESCRIPTION
The conditional suffix check is no longer needed as we want to always use the -dev suffix for consistency