### PR TITLE
ci(docker): conditionally enable dev suffix based on branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,7 +61,7 @@ jobs:
             type=sha,format=short
           flavor: |
             latest=auto
-            suffix=-dev
+            suffix=-dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Push image to GitHub Container Registry
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Only apply the -dev suffix when building from the dev branch to avoid confusion in other environments