### PR TITLE
ci(docker): set image suffix based on branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,8 +29,10 @@ jobs:
         run: |
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "IMAGE_NAME=${{ env.IMAGE_NAME_PROD }}" >> $GITHUB_ENV
+            echo "IMAGE_SUFFIX=" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF_NAME}" == "dev" ]]; then
             echo "IMAGE_NAME=${{ env.IMAGE_NAME_DEV }}" >> $GITHUB_ENV
+            echo "IMAGE_SUFFIX=-dev" >> $GITHUB_ENV
           fi
 
       # - name: Log in to Docker Hub
@@ -61,8 +63,7 @@ jobs:
             type=sha,format=short
           flavor: |
             latest=auto
-            suffix=-dev
-            suffix-enabled=${{ github.ref == 'refs/heads/dev' }}
+            suffix=${{ env.IMAGE_SUFFIX }}
 
       - name: Push image to GitHub Container Registry
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Use IMAGE_SUFFIX environment variable to simplify docker image tagging