### PR TITLE
ci(docker): update image tagging to use tags instead of main branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,9 +56,9 @@ jobs:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPO }}/${{ env.IMAGE_NAME }}
           tags: |
             # Main branch: latest, semver, sha
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=semver,pattern={{version}},enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,format=short,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             # Dev branch: latest-dev, semver-dev, sha-dev
             type=raw,value=latest${{ env.IMAGE_SUFFIX }},enable=${{ github.ref == 'refs/heads/dev' }}
             type=semver,pattern={{version}}${{ env.IMAGE_SUFFIX }},enable=${{ github.ref == 'refs/heads/dev' }}


### PR DESCRIPTION
Change image tagging condition from main branch to version tags (v*). This ensures proper versioned releases while maintaining dev branch tagging.